### PR TITLE
exercise-session skill: 5 refinements from 2026-05-02 PV session

### DIFF
--- a/.claude/skills/exercise-session/SKILL.md
+++ b/.claude/skills/exercise-session/SKILL.md
@@ -47,6 +47,11 @@ format. Extract:
 
 Combine with stable profile from `family-profiles.md`.
 
+**Apply engagement-notes from the first reply, not just during item delivery.**
+Stated style preferences (concision, format, length) are binding from message 1.
+If you don't match them from the open, you're already off-protocol — the player
+will have to pushback before you've even started Step 2. Draft and trim before sending.
+
 ### Step 2 — Select exercise type
 
 Match player's profile + recent weak patterns + (for Artem) slot plan.
@@ -59,6 +64,12 @@ ambiguity.
 `error_correction`). `particle_sort` for particle sorts (NOT `transform`). Slot-matching
 depends on exact values.
 
+**Two-stage PV format** (Artem default, validated 2026-05-02): 10 `particle_sort`
+items as warm-up + 5 `transform` items on the same verb families. Log as **two
+separate exercise entries** — different `exercise` types keep stats and
+slot-matching clean. Use this whenever the session targets PV production; it
+honours Artem's recognition→production ladder rule.
+
 ### Step 3 — Run session
 
 Present items one at a time. Score each. Build error pattern map.
@@ -66,6 +77,20 @@ Present items one at a time. Score each. Build error pattern map.
 For each item, use the player's real-life context themes from `family-profiles.md`.
 Default to home/Bahrain context unless Artem mentioned travel at session start.
 **Generic stems are forbidden** ("the man went to the shop" — never).
+
+**L1 fallback for grammar trap explanations.** Even for English-default players
+(coach_language=`en`), switch to L1 (Russian) when the player asks for a deeper
+explanation on an error — especially L1 interference patterns (Russian
+direct-object → English preposition, fossilised article calques, particle
+semantics that don't map to Russian intuition). Don't pre-switch unprompted; do
+switch on request.
+
+**Two-stage sessions: deliberate retest of recognition misses.** When running
+the recognition→production ladder, **at least one production item must retest
+a recognition miss** from the warm-up. Confirms whether the gap is real or a
+single slip. If the player gets it right on retest → log as "recognition slip,
+production fine". If wrong both times → log as confirmed stuck pattern (high
+priority for next session).
 
 ### Logging strategy
 

--- a/references/exercise-types.md
+++ b/references/exercise-types.md
@@ -75,6 +75,14 @@ is the **base verb only** (e.g. `GET`, `BRING`, `TAKE`) — never the verb+parti
 which is exactly the rung being practised. Player must produce the particle from semantic
 understanding. (Set 2026-04-30 after a PV Family Drill leaked `GET ACROSS` as the keyword.)
 
+**Half-credit scoring rule**: award 0.5 when the **target structure** (e.g. correct
+particle in PV transform) is produced but adjacent grammar leaks (tense drift,
+preposition omission, agreement). This separates "production gap" from "load drift" —
+both worth logging but they imply different next sessions. Record full marks and half
+marks distinctly in `meta.scoring_note`. (Set 2026-05-02 after a PV transform session
+where particle-correct/tense-wrong items would have lost diagnostic granularity if
+scored as full misses.)
+
 Example:
 - Source: "I realised the cost only after reviewing the invoice."
 - Keyword: ONLY (must appear in transformed version)


### PR DESCRIPTION
## Summary

Five skill refinements proposed and approved during the 2026-05-02 Artem PV session. All changes documentation-only — no code or question-bank impact.

### `.claude/skills/exercise-session/SKILL.md`

1. **Step 1**: `engagement_notes` apply from the **first reply**, not just during item delivery. Triggered by my opening this session verbose despite Artem's existing "concise, direct" preference.
2. **Step 2**: name the **two-stage PV format** (10 `particle_sort` + 5 `transform`, logged as two separate exercise entries). Validated in this session (combined 73% vs 63% last cold-start PV drill).
3. **Step 3**: **L1 fallback for grammar trap explanations** — switch to Russian on player request even when `coach_language=en`, especially for L1 interference patterns.
4. **Step 3**: in two-stage sessions, **at least one production item must retest a recognition miss** from the warm-up. Distinguishes confirmed stuck patterns from one-off slips.

### `references/exercise-types.md` §4 (transform)

5. **Half-credit scoring rule**: 0.5 when target structure (e.g. correct PV particle) is produced but adjacent grammar leaks (tense drift, preposition omission). Separates "production gap" from "load drift" diagnostically.

## Test plan

- [ ] Next PV session for Artem follows the named two-stage format
- [ ] Half-credit scoring surfaces correctly in `meta.scoring_note` of new transform logs
- [ ] Engagement-notes-from-message-1 discipline holds in next CC-driven session
- [ ] L1 fallback rule applied without need for player to request twice

https://claude.ai/code/session_014MxCQptLwePNQp4dQBCo4L

---
_Generated by [Claude Code](https://claude.ai/code/session_014MxCQptLwePNQp4dQBCo4L)_