### PR TITLE
profiles: artem stems use operational register, not pitch-deck

### DIFF
--- a/references/family-profiles.md
+++ b/references/family-profiles.md
@@ -36,6 +36,7 @@ accuracy alongside being a player.
 **Exercise context themes**:
 - Default: business meetings, O&G operations, finance, strategy, Bahrain settings
 - Cycling and sports as recurring fallback
+- Avoid pitch-deck register (step-change, unit costs across upstream, strategy review). Use operational/hallway English — "never got around to it last quarter," "contractor's pushing back," "let's crack on."
 - If Artem mentions travel at session start ("we're in Turkey this week"), shift to location-appropriate scenarios for that session
 
 **Weekly slot plan**: see `weekly-slots.md`.


### PR DESCRIPTION
## Summary
- Adds one line to Artem's **Exercise context themes** in `family-profiles.md` directing CC-side authoring away from pitch-deck/strategy-presentation register toward operational/hallway English.
- Promoted from durable feedback in the PV two-stage session 2026-05-03: stems like "step-change in unit costs across upstream" / "Manama strategy review" felt like exam questions rather than language Artem actually produces.

## Test plan
- [ ] Next CC-authored exercise session for Artem uses operational stems (no pitch-deck register).
- [ ] Reads cleanly alongside existing themes; no conflict with Bahrain / O&G default.

https://claude.ai/code/session_01BxQkfKFBcDWQHJcsNxcw9c

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxQkfKFBcDWQHJcsNxcw9c)_