### PR TITLE
hooks: add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# This repo has zero third-party dependencies — tools/*.js use Node 18+
+# built-ins only (fetch, fs, path). The hook's job is to verify Node is
+# available so the lint scripts (node tools/lint_questions.js,
+# node tools/check_transform_keywords.js) and the syntax-check loop
+# (node --check) work as soon as the session starts.
+#
+# Idempotent. Non-interactive. Web-only.
+
+set -euo pipefail
+
+# Skip on local laptop sessions — Node is already set up there.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "ERROR: node not found in PATH" >&2
+  echo "       tools/*.js scripts and CI lint commands require Node 18+." >&2
+  exit 1
+fi
+
+NODE_MAJOR=$(node -p "process.versions.node.split('.')[0]")
+if [ "$NODE_MAJOR" -lt 18 ]; then
+  echo "ERROR: Node $NODE_MAJOR is too old; tools/_firestore.js needs Node 18+ (built-in fetch)." >&2
+  exit 1
+fi
+
+echo "Node $(node --version) ready. No npm install needed (zero third-party deps)."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,18 @@
     "enabledMcpjsonServers":  [
                                   "firebase"
                               ],
+    "hooks":  {
+                  "SessionStart":  [
+                                       {
+                                           "hooks":  [
+                                                         {
+                                                             "type":  "command",
+                                                             "command":  "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+                                                         }
+                                                     ]
+                                       }
+                                   ]
+              },
     "permissions":  {
                         "allow":  [
                                       "Bash(node --check *)",


### PR DESCRIPTION
## Summary
- Adds `.claude/hooks/session-start.sh`: verifies Node 18+ is on PATH so `tools/*.js` and the CI syntax-check loop work as soon as a remote session starts. No-op on laptop sessions (`CLAUDE_CODE_REMOTE` guard).
- Registers the hook under `SessionStart` in `.claude/settings.json`.
- Repo has zero third-party deps (Node 18+ built-in `fetch`/`fs`/`path`), so no `npm install` step is needed — the hook is a fast environment sanity check.

## Test plan
- [x] Hook runs cleanly with `CLAUDE_CODE_REMOTE=true` (prints Node version, exit 0)
- [x] Hook is a silent no-op without `CLAUDE_CODE_REMOTE` (laptop)
- [x] `node tools/lint_questions.js` → `OK — 2025 questions checked`
- [x] `node --check tools/lint_questions.js` → exit 0
- [x] `.claude/settings.json` parses as JSON

Hook execution mode: **synchronous** — guarantees Node is verified before the session starts.

https://claude.ai/code/session_01H7D3EZSvNe2zUf88e8k7tN

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7D3EZSvNe2zUf88e8k7tN)_